### PR TITLE
#24 - fail to check line in boundaries

### DIFF
--- a/PlancakeEmailParser.php
+++ b/PlancakeEmailParser.php
@@ -207,7 +207,7 @@ class PlancakeEmailParser {
         $boundaries = $matches[1];
         // sometimes boundaries are delimited by quotes - we want to remove them
         foreach($boundaries as $i => $v) {
-            $boundaries[$i] = str_replace(array("'", '"'), '', $v);
+            $boundaries[$i] = trim(str_replace(array("'", '"'), '', $v));
         }
         
         foreach ($this->rawBodyLines as $line) {


### PR DESCRIPTION
#24 - I have a problem, when I use function 'getBody()'
The boundaries array should have no space, but it's not.
```
if (is_array($boundaries)) {
    if (in_array(substr($line, 2), $boundaries)) {  // found the delimiter
        break;
    }
}
```
When checking line in boundaries array, It's fail always in my case.

Please review my pull request.

p.s. It's my first time to pull request in GitHub and my eng. is not good. :)
Thanks.