### PR TITLE
Tiny fix for the boundary parsing

### DIFF
--- a/PlancakeEmailParser.php
+++ b/PlancakeEmailParser.php
@@ -203,7 +203,7 @@ class PlancakeEmailParser {
             $contentTypeRegex = '/^Content-Type: ?text\/plain/i';
         
         // there could be more than one boundary
-        preg_match_all('!boundary=(.*)$!mi', $this->emailRawContent, $matches);
+        preg_match_all('!boundary=(.*?)[;$]!mi', $this->emailRawContent, $matches);
         $boundaries = $matches[1];
         // sometimes boundaries are delimited by quotes - we want to remove them
         foreach($boundaries as $i => $v) {


### PR DESCRIPTION
A better boundary detection that won't fail on such example:
Content-Type: multipart/report; 
	boundary="----=_Part_2509169_1730566862.1445846478023"; 
	report-type=delivery-status